### PR TITLE
grouped both actions into a single toolbutton with a menu

### DIFF
--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -67,10 +67,19 @@ class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
 class ReloaderPlugin():
   def __init__(self, iface):
     self.iface = iface
-
+    self.toolBar = self.iface.addToolBar(u"PluginReloader")
+    self.toolBar.setObjectName(u"PluginReloader")
+    self.toolButton = QToolButton()
+    self.toolButton.setMenu(QMenu())
+    self.toolButton.setPopupMode(QToolButton.MenuButtonPopup)
+    self.iface.addToolBarWidget(self.toolButton)
 
   def initGui(self):
-    self.actionRun = QAction(QIcon(":/plugins/plugin_reloader/reload.png"), u"Reload chosen plugin", self.iface.mainWindow())
+    self.actionRun = QAction(
+      QIcon(":/plugins/plugin_reloader/reload.png"), 
+      u"Reload chosen plugin", 
+      self.iface.mainWindow()
+    )
     self.iface.registerMainWindowAction(self.actionRun, "F5")
     self.actionRun.setWhatsThis(u"Reload chosen plugin")
     plugin = currentPlugin()
@@ -78,12 +87,18 @@ class ReloaderPlugin():
       self.actionRun.setWhatsThis(u"Reload plugin: %s" % plugin)
       self.actionRun.setText(u"Reload plugin: %s" % plugin)
     self.iface.addPluginToMenu("&Plugin Reloader", self.actionRun)
-    self.iface.addToolBarIcon(self.actionRun)
+    m = self.toolButton.menu()
+    m.addAction(self.actionRun)
+    self.toolButton.setDefaultAction(self.actionRun)
     QObject.connect(self.actionRun, SIGNAL("triggered()"), self.run)
-    self.actionConfigure = QAction(QIcon(":/plugins/plugin_reloader/reload-conf.png"), u"Choose a plugin to be reloaded", self.iface.mainWindow())
+    self.actionConfigure = QAction(
+      QIcon(":/plugins/plugin_reloader/reload-conf.png"), 
+      u"Choose a plugin to be reloaded", 
+      self.iface.mainWindow()
+    )
     self.iface.registerMainWindowAction(self.actionConfigure, "Shift+F5")
     self.actionConfigure.setWhatsThis(u"Choose a plugin to be reloaded")
-    self.iface.addToolBarIcon(self.actionConfigure)
+    m.addAction(self.actionConfigure)
     self.iface.addPluginToMenu("&Plugin Reloader", self.actionConfigure)
     QObject.connect(self.actionConfigure, SIGNAL("triggered()"), self.configure)
 

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -67,8 +67,6 @@ class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
 class ReloaderPlugin():
   def __init__(self, iface):
     self.iface = iface
-    self.toolBar = self.iface.addToolBar(u"PluginReloader")
-    self.toolBar.setObjectName(u"PluginReloader")
     self.toolButton = QToolButton()
     self.toolButton.setMenu(QMenu())
     self.toolButton.setPopupMode(QToolButton.MenuButtonPopup)


### PR DESCRIPTION
This pull request groups the run and configre actions into a single tool button.
#### Current implementation

The current implementation adds two buttons to the plugins toolbar. One button allows reloading a plugin and the other button allows selecting which plugin should be reloaded:
![old_behaviour](https://cloud.githubusercontent.com/assets/732010/7934452/84e55518-091f-11e5-9714-b46b53504aa7.png)
#### Proposed change

The proposed change condenses these two actions under a single button. The button includes a dropdown that exposes a menu when selected. The menu holds both the run and configure actions:
![new_collapsed](https://cloud.githubusercontent.com/assets/732010/7934465/8fe3f53c-091f-11e5-8492-641a30f74fd1.png)

![new_open](https://cloud.githubusercontent.com/assets/732010/7934467/94674226-091f-11e5-9399-a570c35adc37.png)

The proposed change:
- Does not affect the core functionality of the plugin in any way. Things still work the same
- Is inline with other tools in QGIS' interface, which also use this approach
- Saves some screen space for having moar plugins visible :)
