### PR TITLE
Add ability to run extra commands before reloading plugin

### DIFF
--- a/configurereloaderbase.ui
+++ b/configurereloaderbase.ui
@@ -7,14 +7,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>367</width>
-    <height>174</height>
+    <width>500</width>
+    <height>250</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="maximumSize">
    <size>
     <width>500</width>
-    <height>200</height>
+    <height>300</height>
    </size>
   </property>
   <property name="contextMenuPolicy">
@@ -26,73 +32,18 @@
   <property name="whatsThis">
    <string/>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="cbNotifications">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Push a notification about the successful reload to the QGIS message bar.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Chceck this&lt;/span&gt;, it you like to be sure you reloaded the rigth plugin.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Uncheck this&lt;/span&gt;, if you hate trivial notifications covering error messages fom the plugin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Display a notification once the plugin is reloaded</string>
+      <string>Select &amp;the plugin you want to reload</string>
+     </property>
+     <property name="buddy">
+      <cstring>comboPlugin</cstring>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
-       <property name="focusPolicy">
-        <enum>Qt::NoFocus</enum>
-       </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-       <property name="centerButtons">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="3">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Preferred</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Preferred</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
+   <item>
     <widget class="QComboBox" name="comboPlugin">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -111,57 +62,44 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="label">
+   <item>
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Select &amp;the plugin you want to reload</string>
-     </property>
-     <property name="buddy">
-      <cstring>comboPlugin</cstring>
+      <string>Commands to run before reloading</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <spacer name="verticalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item>
+    <widget class="QPlainTextEdit" name="pteExtraCommands"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="cbNotifications">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Push a notification about the successful reload to the QGIS message bar.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Chceck this&lt;/span&gt;, it you like to be sure you reloaded the rigth plugin.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Uncheck this&lt;/span&gt;, if you hate trivial notifications covering error messages fom the plugin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
+     <property name="text">
+      <string>Display a notification once the plugin is reloaded</string>
      </property>
-    </spacer>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -80,6 +80,19 @@ class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
     self.iface = parent
     self.setupUi(self)
     self.cbNotifications.setChecked(notificationsEnabled())
+    self.pteExtraCommands.setToolTip(
+       QCoreApplication.translate(
+           'ReloaderPlugin',
+           (
+               '<html><head/><body>'
+               '<p>QGIS will try to execute any commands typed here in a shell '
+               'before reloading the plugin.</p>'
+               '<p>This can be useful, for example, if you '
+               'need to copy the new source code into the QGIS plugins directory.</p>'
+               '</body></html>'
+           )
+       )
+    )
     self.pteExtraCommands.setPlainText(getExtraCommands())
 
     #update the plugin list first! The plugin could be removed from the list if was temporarily broken.


### PR DESCRIPTION
This PR implements a simple mechanism to allow running external commands before reloading a plugin.

The use case it tries to cover is plugin devs that work on their code on directories outside of QGIS' default plugin dirs - as is my own case :wink: 

By using the proposed implementation I am able to configure an external command that should be run just before QGIS reloads my plugin - this command proceeds to put my code inside QGIS' plugins dir, where it may then be reloaded.

The proposed implementation changes the configure dialog to something like the below screenshot:

![plugin_reloader_extra_commands](https://user-images.githubusercontent.com/732010/103229448-ee46bf00-492a-11eb-971b-07ffe0b93e06.png)

As depicted in the screenshot, the configure dialog now features an additional text edit widget where the user can input the command(s) that should be run before reloading the plugin. the image shows how I am running the following command:

```
# change dir to where plugin code is developed, then use my loader script to put it in QGIS plugins dir
cd ~/dev/{plugin-dir} &&
    poetry run python pluginadmin.py install --verbose install
```

Personally this would give me a considerable productivity boost, as I'd be able to fulfill all my reloading tasks directly inside QGIS, without having to go to the terminal between reloads.