### PR TITLE
Option to append plugin' name to the extra commands typed

### DIFF
--- a/configurereloaderbase.ui
+++ b/configurereloaderbase.ui
@@ -78,7 +78,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="cbAppendPluginName">
+    <widget class="QCheckBox" name="cbReplacePluginName">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -86,10 +86,10 @@
       </sizepolicy>
      </property>
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Will change a command like&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py&lt;/span&gt;&lt;/p&gt;&lt;p&gt;to&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py plugin_reloader&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Will change a command like&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py %PluginName%&lt;/span&gt;&lt;/p&gt;&lt;p&gt;to&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py plugin_reloader&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Append plugin's name to the command typed</string>
+      <string>Replace %PluginName% anywhere in the command typed by the plugin's name</string>
      </property>
     </widget>
    </item>

--- a/configurereloaderbase.ui
+++ b/configurereloaderbase.ui
@@ -78,6 +78,22 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="cbAppendPluginName">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Will change a command like&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py&lt;/span&gt;&lt;/p&gt;&lt;p&gt;to&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;python makeBackup.py plugin_reloader&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Append plugin's name to the command typed</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="cbNotifications">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -38,9 +38,9 @@ def setCurrentPlugin(plugin):
     settings = QSettings()
     settings.setValue('/PluginReloader/plugin', plugin)
 
-def appendPluginNameEnabled():
+def replacePluginNameEnabled():
     settings = QSettings()
-    return settings.value('/PluginReloader/appendPluginName', True, type=bool)
+    return settings.value('/PluginReloader/replacePluginName', True, type=bool)
 
 def notificationsEnabled():
     settings = QSettings()
@@ -50,11 +50,11 @@ def getExtraCommands():
     settings = QSettings()
     return settings.value('/PluginReloader/extraCommands', '')
 
-def setAppendPluginNameEnabled(enabled):
+def setReplacePluginNameEnabled(enabled):
     ''' param enabled (bool): Yes or no I'm asking?
     '''
     settings = QSettings()
-    return settings.setValue('/PluginReloader/appendPluginName', enabled)
+    return settings.setValue('/PluginReloader/replacePluginName', enabled)
 
 def setNotificationsEnabled(enabled):
     ''' param enabled (bool): Yes or no I'm asking?
@@ -70,8 +70,8 @@ def handleExtraCommands(message_bar, translator):
     extra_commands = getExtraCommands()
     if extra_commands != "":
         try:
-            if appendPluginNameEnabled():
-                extra_commands += " " + currentPlugin()
+            if replacePluginNameEnabled():
+                extra_commands = extra_commands.replace('%PluginName%', currentPlugin())
             
             completed_process = subprocess.run(
                 extra_commands,
@@ -92,7 +92,7 @@ class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
     super().__init__()
     self.iface = parent
     self.setupUi(self)
-    self.cbAppendPluginName.setChecked(appendPluginNameEnabled())
+    self.cbReplacePluginName.setChecked(replacePluginNameEnabled())
     self.cbNotifications.setChecked(notificationsEnabled())
     self.pteExtraCommands.setPlainText(getExtraCommands())
 
@@ -262,6 +262,6 @@ class ReloaderPlugin():
       self.actionRun.setToolTip(self.tr('Reload plugin: {}').format(plugin))
       self.actionRun.setText(self.tr('Reload plugin: {}').format(plugin))
       setCurrentPlugin(plugin)
-      setAppendPluginNameEnabled(dlg.cbAppendPluginName.isChecked())
+      setReplacePluginNameEnabled(dlg.cbReplacePluginName.isChecked())
       setNotificationsEnabled(dlg.cbNotifications.isChecked())
       setExtraCommands(dlg.pteExtraCommands.toPlainText())

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -38,6 +38,10 @@ def setCurrentPlugin(plugin):
     settings = QSettings()
     settings.setValue('/PluginReloader/plugin', plugin)
 
+def appendPluginNameEnabled():
+    settings = QSettings()
+    return settings.value('/PluginReloader/appendPluginName', True, type=bool)
+
 def notificationsEnabled():
     settings = QSettings()
     return settings.value('/PluginReloader/notify', True, type=bool)
@@ -45,6 +49,12 @@ def notificationsEnabled():
 def getExtraCommands():
     settings = QSettings()
     return settings.value('/PluginReloader/extraCommands', '')
+
+def setAppendPluginNameEnabled(enabled):
+    ''' param enabled (bool): Yes or no I'm asking?
+    '''
+    settings = QSettings()
+    return settings.setValue('/PluginReloader/appendPluginName', enabled)
 
 def setNotificationsEnabled(enabled):
     ''' param enabled (bool): Yes or no I'm asking?
@@ -60,6 +70,9 @@ def handleExtraCommands(message_bar, translator):
     extra_commands = getExtraCommands()
     if extra_commands != "":
         try:
+            if appendPluginNameEnabled():
+                extra_commands += " " + currentPlugin()
+            
             completed_process = subprocess.run(
                 extra_commands,
                 shell=True,
@@ -79,6 +92,7 @@ class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
     super().__init__()
     self.iface = parent
     self.setupUi(self)
+    self.cbAppendPluginName.setChecked(appendPluginNameEnabled())
     self.cbNotifications.setChecked(notificationsEnabled())
     self.pteExtraCommands.setPlainText(getExtraCommands())
 
@@ -248,5 +262,6 @@ class ReloaderPlugin():
       self.actionRun.setToolTip(self.tr('Reload plugin: {}').format(plugin))
       self.actionRun.setText(self.tr('Reload plugin: {}').format(plugin))
       setCurrentPlugin(plugin)
+      setAppendPluginNameEnabled(dlg.cbAppendPluginName.isChecked())
       setNotificationsEnabled(dlg.cbNotifications.isChecked())
       setExtraCommands(dlg.pteExtraCommands.toPlainText())


### PR DESCRIPTION
Adds a checkbox to automatically append the plugin's name to the command. That way, I can let a script manage the origin and destination of files based (copying from dev directory to QGIS plugin directory):

![image](https://user-images.githubusercontent.com/32580398/133643041-ce5e4589-c797-420a-90df-4b4794e1884e.png)

Currently, I have to type in the extra commands text box something like `python C:\dev\copyMyPlugin.py pluginUnderDevelopment`. With his PR, I only need to type  `python C:\dev\copyMyPlugin.py` and the `pluginUnderDevelopment` will be appended as the last argument automatically. That way, if I now switch my development to `coolOtherPlugin`, I don't have to change anything in my command and risk messing things up by misspelling the name for example.

**Second thoughs**
It may not be the best approach. I was also thinking of simply adding a function to replace a specific string like `%PluginName%` by the plugin's name everywhere in the command string. That way, the name can be used at multiple places instead of just at the end. I would be replacing `extra_commands += " " + currentPlugin()` by `extra_commands = extra_commands.replace('%PluginName%', currentPlugin())`. I think it would have the added benefit to be more explicit.


