### PR TITLE
Allow temporary disabling of Extra commands

### DIFF
--- a/configurereloaderbase.ui
+++ b/configurereloaderbase.ui
@@ -63,9 +63,19 @@
     </widget>
    </item>
    <item>
-    <widget class="QLabel" name="label_2">
+    <widget class="QCheckBox" name="cbExtraCommands">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;QGIS will try to execute any commands typed here in a shell before reloading the plugin.&lt;/p&gt;
+&lt;p&gt;This can be useful, for example, if you need to copy the new source code into the QGIS plugins directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Commands to run before reloading</string>
+      <string>Run the commands below before reloading</string>
      </property>
     </widget>
    </item>

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -52,6 +52,14 @@ def setNotificationsEnabled(enabled):
     settings = QSettings()
     return settings.setValue('/PluginReloader/notify', enabled)
 
+def extraCommandsEnabled():
+    settings = QSettings()
+    return settings.value('/PluginReloader/extraCommandsEnabled', True, type=bool)
+
+def setExtraCommandsEnabled(enabled):
+    settings = QSettings()
+    return settings.setValue('/PluginReloader/extraCommandsEnabled', enabled)
+
 def setExtraCommands(commands):
     settings = QSettings()
     return settings.setValue('/PluginReloader/extraCommands', commands)
@@ -232,8 +240,9 @@ class ReloaderPlugin():
           if hasattr(sys.modules[key], 'qCleanupResources'):
             sys.modules[key].qCleanupResources()
           del sys.modules[key]
-
-      handleExtraCommands(self.iface.messageBar(), self.tr)
+      
+      if extraCommandsEnabled():
+        handleExtraCommands(self.iface.messageBar(), self.tr)
       reloadPlugin(plugin)
       self.iface.mainWindow().restoreState(state)
       if notificationsEnabled():
@@ -249,4 +258,5 @@ class ReloaderPlugin():
       self.actionRun.setText(self.tr('Reload plugin: {}').format(plugin))
       setCurrentPlugin(plugin)
       setNotificationsEnabled(dlg.cbNotifications.isChecked())
+      setExtraCommandsEnabled(dlg.cbExtraCommands.isChecked())
       setExtraCommands(dlg.pteExtraCommands.toPlainText())

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -66,21 +66,20 @@ def setExtraCommands(commands):
 
 def handleExtraCommands(message_bar, translator):
     extra_commands = getExtraCommands()
-    if extra_commands != "":
-        try:
-            completed_process = subprocess.run(
-                extra_commands,
-                shell=True,
-                capture_output=True,
-                check=True,
-                text=True,
-            )
-            message_bar.pushMessage(completed_process.stdout, Qgis.Info)
-        except subprocess.CalledProcessError as exc:
-            message_bar.pushMessage(
-                translator('Could not execute extra commands: {}').format(exc.stderr),
-                Qgis.Warning
-            )
+    try:
+        completed_process = subprocess.run(
+            extra_commands,
+            shell=True,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        message_bar.pushMessage(completed_process.stdout, Qgis.Info)
+    except subprocess.CalledProcessError as exc:
+        message_bar.pushMessage(
+            translator('Could not execute extra commands: {}').format(exc.stderr),
+            Qgis.Warning
+        )
 
 class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
   def __init__(self, parent):


### PR DESCRIPTION
Replace the text `Commands to run before reloading` by a checkbox to allow temporary disabling of Extra commands. Currently, the command is always run.

![2021-10-17_000893](https://user-images.githubusercontent.com/32580398/137647661-a091a1bb-1093-494c-99d6-26ecb1c65a01.png)

If merged, I think I'll push this a bit further in order to enable/disable the PlanTextEdit dynamically. I already have some pieces but I think it will need more work on the way the config windows is currently coded.