### PR TITLE
%PluginPath% joker

### DIFF
--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -16,7 +16,6 @@
 # ***************************************************************************
 
 import os
-import glob
 import sys
 import subprocess
 from time import time
@@ -24,7 +23,7 @@ from qgis.PyQt.QtCore import *
 from qgis.PyQt.QtGui import *
 from qgis.PyQt.QtWidgets import *
 from qgis.PyQt import uic
-from qgis.core import Qgis, QgsApplication
+from qgis.core import Qgis
 from qgis.utils import plugins, reloadPlugin, updateAvailablePlugins, unloadPlugin, loadPlugin, startPlugin
 from pyplugin_installer import installer as plugin_installer
 
@@ -71,7 +70,7 @@ def handleExtraCommands(message_bar, translator):
     extraCommands = getExtraCommands()
     if extraCommands.strip() != "":  # Prevent an empty command to be run
       extraCommands = extraCommands.replace('%PluginName%', currentPlugin())
-      extraCommands = extraCommands.replace('%PluginPath%', findPluginPath(currentPlugin()))
+      extraCommands = extraCommands.replace('%PluginPath%', plugin_installer.plugins.all()[currentPlugin()]['library']
 
       completed_process = subprocess.run(
         extraCommands,
@@ -95,28 +94,6 @@ def handleExtraCommands(message_bar, translator):
     successExtraCommands = False
       
   return successExtraCommands
-
-def findPluginPath(pluginName):
-  # Get plugins directory from active profile
-  qgisPluginDirPaths = [os.path.join(QgsApplication.qgisSettingsDirPath(), 'python/plugins')]
-
-  # Get plugins directories from QGIS_PLUGINPATH if environment variable is set
-  # It must be noted that the path order in QGIS_PLUGINPATH matters if the same plugin
-  # is found in more than one path as the first match has priority.
-  if 'QGIS_PLUGINPATH' in os.environ:
-    qgisPluginDirPaths = os.environ['QGIS_PLUGINPATH'].split(os.pathsep) + qgisPluginDirPaths
-  
-  # Look for pluginName in each possible directory following
-  # prioritization order: profile -> QGIS_PLUGINPATH
-  for qgisPluginDirPath in reversed(qgisPluginDirPaths):
-    path_plugins = glob.glob(qgisPluginDirPath + '/*/')
-    name_plugins = [os.path.basename(os.path.dirname(x)) for x in path_plugins]
-    
-    if pluginName in name_plugins:
-      idx = name_plugins.index(pluginName)
-      pluginPath = path_plugins[idx]
-  
-  return os.path.normpath(pluginPath)
 
 class ConfigureReloaderDialog (QDialog, Ui_ConfigureReloaderDialogBase):
   def __init__(self, parent):

--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -70,7 +70,7 @@ def handleExtraCommands(message_bar, translator):
     extraCommands = getExtraCommands()
     if extraCommands.strip() != "":  # Prevent an empty command to be run
       extraCommands = extraCommands.replace('%PluginName%', currentPlugin())
-      extraCommands = extraCommands.replace('%PluginPath%', plugin_installer.plugins.all()[currentPlugin()]['library']
+      extraCommands = extraCommands.replace('%PluginPath%', plugin_installer.plugins.all()[currentPlugin()]['library'])
 
       completed_process = subprocess.run(
         extraCommands,


### PR DESCRIPTION
I could very well be in feature creep territory with this one... If so, let me know.

# Function
Very similar to the _%PluginName%_ now available when passing an extra command, this _%PluginPath%_ fetch the directory path of the soon-to-be reloaded plugin. Looks for plugins in both active profile and directories set by QGIS_PLUGINPATH environment variable.

# Why
Maybe my workflow is bad, but working on multiple plugins not always stored in the same root directory (for GIT purpose), I had a need to easily copy my development version in the appropriate QGIS plugin directory for testing purpose. By exposing the current plugin path, I can call a small python script that copy the appropriate files to the right directory depending on the plugin name just before reloading. I suppose (hope) I'm not the only one in this situation.

# Additional note
I didn't add text on the UI to tell the user that _%PluginPath%_ is available yet.