### PR TITLE
Run extraCommands sooner

### DIFF
--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -227,6 +227,11 @@ class ReloaderPlugin():
     self.iface.removeToolBarIcon(self.toolBtnAction)
 
   def run(self):
+    if extraCommandsEnabled():
+      successExtraCommands = handleExtraCommands(self.iface.messageBar(), self.tr)
+      if not successExtraCommands:
+        return
+
     plugin = currentPlugin()
 
     #update the plugin list first! The plugin could be removed from the list if was temporarily broken.
@@ -254,11 +259,6 @@ class ReloaderPlugin():
           if hasattr(sys.modules[key], 'qCleanupResources'):
             sys.modules[key].qCleanupResources()
           del sys.modules[key]
-
-      if extraCommandsEnabled():
-        successExtraCommands = handleExtraCommands(self.iface.messageBar(), self.tr)
-        if not successExtraCommands:
-          return
       
       # Reload plugin and check if it was successful.
       # Starting with QGIS 3.22, qgis.utils.reloadPlugin() returns True/False


### PR DESCRIPTION
Run the extra command right after the user clicked the Reload button instead of after `updateAvailablePlugins()`. Running it after could be a problem if the current version of the plugin is broken as it would raise an error and prevent the command to be run.

The current behavior might or might not be a problem depending of what extraCommands is used for. In my case, as I use it to copy the development plugin from my GIT folder to the QGIS plugins folder, having a broken plugin prevent the copy to be done and thus to reload a now fixed plugin.

I don't think that bringing execution of extraCommands sooner would have any adversarial effects as it is expected to be run before everything else.