### PR TITLE
Rebuilt plugin list at first startup

### DIFF
--- a/reloader_plugin.py
+++ b/reloader_plugin.py
@@ -230,6 +230,9 @@ class ReloaderPlugin():
     self.iface.removeToolBarIcon(self.toolBtnAction)
 
   def run(self):
+    if len(plugin_installer.plugins.all()) == 0:
+      plugin_installer.plugins.rebuild()
+
     if extraCommandsEnabled():
       successExtraCommands = handleExtraCommands(self.iface.messageBar(), self.tr)
       if not successExtraCommands:
@@ -284,6 +287,9 @@ class ReloaderPlugin():
           )
 
   def configure(self):
+    if len(plugin_installer.plugins.all()) == 0:
+      plugin_installer.plugins.rebuild()
+    
     dlg = ConfigureReloaderDialog(self.iface)
     dlg.exec_()
     if dlg.result():


### PR DESCRIPTION
Currently, no plugin icons are shown in the selection menu of the configurator at startup. This happens because the call `plugin_installer.plugins.all()` returns an empty dict by default *unless* the Plugin Manager has been opened before.

https://github.com/borysiasty/plugin_reloader/blob/6c82e431404c3fe4d54b0d80f1c310507c01cd04/reloader_plugin.py#L122

There is probably a better way to do it, but by calling `plugin_installer.plugins.rebuild()` when the configurator is opened, the dict is filled and the icons are thus properly shown.

I also added the same call when the Reload button is pressed in order to avoid a crash if an extra command is used because of line 73.
https://github.com/borysiasty/plugin_reloader/blob/6c82e431404c3fe4d54b0d80f1c310507c01cd04/reloader_plugin.py#L71-L73