### PR TITLE
deleted saving main window state while reloading

### DIFF
--- a/Plugin.py
+++ b/Plugin.py
@@ -318,7 +318,6 @@ class Plugin:
 
     def reloadPlugin(self, plugin: str):
         """Reload plugin with submodules and check if it was successful."""
-        windowState = self.iface.mainWindow().saveState()
         startTime = time()
 
         # Try to initially load the selected plugin if not loaded yet
@@ -343,7 +342,6 @@ class Plugin:
         pluginStarted = qgis.utils.startPlugin(plugin)
 
         endTime = time()
-        self.iface.mainWindow().restoreState(windowState)
 
         if pluginStarted and Settings.notificationsEnabled():
             duration = int(round((endTime - startTime) * 1000))


### PR DESCRIPTION
while working on a qgis plugin i use the plugin reloader (you can imagine).
my plugin adds a new toolbar to the mainWindow and deletes it while unloading.
Due to the saving the window state during the reload there is one more toolbar after the reload: The one created by the plugin after the load, and the old one getting resetted by the plugin_reloader

so i removed the saving window state part.